### PR TITLE
tls-reconnect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,19 +50,19 @@
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                    <version>2.0.5</version>
+                    <version>2.0.6</version>
                 </dependency>
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
-                    <version>2.0.5</version>
+                    <version>2.0.6</version>
                     <scope>test</scope>
                 </dependency>
                 <!-- tls -->
                 <dependency>
                     <groupId>com.github.marianobarrios</groupId>
                     <artifactId>tls-channel</artifactId>
-                    <version>0.6.2</version>
+                    <version>0.7.0</version>
                 </dependency>
                 <dependency>
                         <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/teragrep/rlp_01/RelpClientPlainSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientPlainSocket.java
@@ -110,8 +110,8 @@ class RelpClientPlainSocket extends RelpClientSocket {
                     if (this.socketChannel.finishConnect()) {
                         // Connection established
                         notConnected = false;
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("relpConnection> established");
+                        if (LOGGER.isTraceEnabled()) {
+                            LOGGER.trace("relpConnection> established");
                             try {
                                 Thread.sleep(1 * 1000);
                             } catch (InterruptedException e) {
@@ -130,7 +130,7 @@ class RelpClientPlainSocket extends RelpClientSocket {
     @Override
     void write(ByteBuffer byteBuffer) throws IOException, TimeoutException {
         SelectionKey key = this.socketChannel.register(this.poll, SelectionKey.OP_WRITE);
-        LOGGER.debug("relpConnection.sendRelpRequestAsync> need to write: " + byteBuffer.hasRemaining());
+        LOGGER.trace("relpConnection.sendRelpRequestAsync> need to write: " + byteBuffer.hasRemaining());
 
         while (byteBuffer.hasRemaining()) {
             int nReady = poll.select(this.writeTimeout);
@@ -142,12 +142,12 @@ class RelpClientPlainSocket extends RelpClientSocket {
             while (eventIter.hasNext()) {
                 SelectionKey currentKey = eventIter.next();
                 if (currentKey.isWritable()) {
-                    LOGGER.debug("relpConnection.sendRelpRequestAsync> became writable");
+                    LOGGER.trace("relpConnection.sendRelpRequestAsync> became writable");
                     this.socketChannel.write(byteBuffer);
                 }
                 eventIter.remove();
             }
-            LOGGER.debug("relpConnection.sendRelpRequestAsync> still need to write: "
+            LOGGER.trace("relpConnection.sendRelpRequestAsync> still need to write: "
                         + byteBuffer.hasRemaining());
         }
         key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE);
@@ -172,7 +172,7 @@ class RelpClientPlainSocket extends RelpClientSocket {
         while (eventIter.hasNext()) {
             SelectionKey currentKey = eventIter.next();
             if (currentKey.isReadable()) {
-                LOGGER.debug("relpConnection.readAcks> became readable");
+                LOGGER.trace("relpConnection.readAcks> became readable");
                 readBytes = socketChannel.read(byteBuffer);
             }
             eventIter.remove();

--- a/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
@@ -26,6 +26,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,15 +78,12 @@ public class RelpClientTlsSocket extends RelpClientSocket {
     private SocketChannel socketChannel;
     private Selector selector;
 
-    private final SSLEngine sslEngine;
-
     private TlsChannel tlsChannel = null;
 
-    RelpClientTlsSocket(SSLEngine sslEngine) {
-        this.sslEngine = sslEngine;
+    private final Supplier<SSLEngine> sslEngineSupplier;
 
-        // force client mode
-        this.sslEngine.setUseClientMode(true);
+    RelpClientTlsSocket(Supplier<SSLEngine> sslEngineSupplier) {
+        this.sslEngineSupplier = sslEngineSupplier;
     }
 
     @Override
@@ -104,6 +102,10 @@ public class RelpClientTlsSocket extends RelpClientSocket {
         SelectionKey key = this.socketChannel.register(this.selector, SelectionKey.OP_CONNECT);
         // Async connect
         this.socketChannel.connect(new InetSocketAddress(hostname, port));
+
+        SSLEngine sslEngine = sslEngineSupplier.get();
+        // force client mode
+        sslEngine.setUseClientMode(true);
 
         ClientTlsChannel.Builder builder = ClientTlsChannel.newBuilder(
                 socketChannel,
@@ -166,7 +168,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                     LOGGER.trace("relpConnection.sendRelpRequestAsync> " +
                             "became writable");
                     try {
-                        this.tlsChannel.write(byteBuffer);
+                        int wroteBytes = this.tlsChannel.write(byteBuffer);
                     } catch (NeedsReadException e) {
                         key.interestOps(SelectionKey.OP_READ); // overwrites previous value
                     } catch (NeedsWriteException e) {
@@ -183,6 +185,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
 
     @Override
     void close() throws IOException {
+        tlsChannel.close();
         socketChannel.close();
     }
 
@@ -205,12 +208,17 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                 try {
                     readBytes = tlsChannel.read(byteBuffer);
                 } catch (NeedsReadException e) {
+                    readBytes = 0;
                     key.interestOps(SelectionKey.OP_READ); // overwrites previous value
                 } catch (NeedsWriteException e) {
+                    readBytes = 0;
                     key.interestOps(SelectionKey.OP_WRITE); // overwrites previous value
                 }
             }
             eventIter.remove();
+        }
+        if (readBytes == -1) {
+            throw new IOException("read failed");
         }
         return readBytes;
     }

--- a/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
@@ -130,8 +130,8 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                     if (this.socketChannel.finishConnect()) {
                         // Connection established
                         notConnected = false;
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("relpConnection> established");
+                        if (LOGGER.isTraceEnabled()) {
+                            LOGGER.trace("relpConnection> established");
                             try {
                                 Thread.sleep(1 * 1000);
                             } catch (InterruptedException e) {
@@ -150,7 +150,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
     @Override
     void write(ByteBuffer byteBuffer) throws IOException, TimeoutException {
         SelectionKey key = this.socketChannel.register(this.selector, SelectionKey.OP_WRITE);
-        LOGGER.debug("relpConnection.sendRelpRequestAsync> need to write: " + byteBuffer.hasRemaining());
+        LOGGER.trace("relpConnection.sendRelpRequestAsync> need to write: " + byteBuffer.hasRemaining());
 
         while (byteBuffer.hasRemaining()) {
             int nReady = selector.select(this.writeTimeout);
@@ -163,7 +163,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                 SelectionKey currentKey = eventIter.next();
                 // tlsChannel needs to know about both
                 if (currentKey.isWritable() || currentKey.isReadable()) {
-                    LOGGER.debug("relpConnection.sendRelpRequestAsync> " +
+                    LOGGER.trace("relpConnection.sendRelpRequestAsync> " +
                             "became writable");
                     try {
                         this.tlsChannel.write(byteBuffer);
@@ -175,7 +175,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                 }
                 eventIter.remove();
             }
-            LOGGER.debug("relpConnection.sendRelpRequestAsync> still need to " +
+            LOGGER.trace("relpConnection.sendRelpRequestAsync> still need to " +
                     "write: "
                     + byteBuffer.hasRemaining());
         }
@@ -201,7 +201,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
             SelectionKey currentKey = eventIter.next();
             // tlsChannel needs to know about both
             if (currentKey.isReadable() || currentKey.isWritable()) {
-                LOGGER.debug("relpConnection.readAcks> became readable");
+                LOGGER.trace("relpConnection.readAcks> became readable");
                 try {
                     readBytes = tlsChannel.read(byteBuffer);
                 } catch (NeedsReadException e) {

--- a/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
@@ -168,7 +168,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                     LOGGER.trace("relpConnection.sendRelpRequestAsync> " +
                             "became writable");
                     try {
-                        int wroteBytes = this.tlsChannel.write(byteBuffer);
+                        this.tlsChannel.write(byteBuffer);
                     } catch (NeedsReadException e) {
                         key.interestOps(SelectionKey.OP_READ); // overwrites previous value
                     } catch (NeedsWriteException e) {

--- a/src/main/java/com/teragrep/rlp_01/RelpConnection.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpConnection.java
@@ -146,7 +146,7 @@ public class RelpConnection implements RelpSender {
      * @throws IOException
      */
     public boolean connect(String hostname, int port) throws IOException, IllegalStateException, TimeoutException {
-        LOGGER.debug("relpConnection.connect> entry");
+        LOGGER.trace("relpConnection.connect> entry");
         if (state != RelpConnectionState.CLOSED) {
             throw new IllegalStateException("Session is not closed.");
         }
@@ -163,7 +163,7 @@ public class RelpConnection implements RelpSender {
         long reqId = connectionOpenBatch.putRequest(relpRequest);
         this.sendBatch(connectionOpenBatch);
         boolean openSuccess = connectionOpenBatch.verifyTransaction(reqId);
-        LOGGER.debug("relpConnection.connect> exit with: " + openSuccess);
+        LOGGER.trace("relpConnection.connect> exit with: " + openSuccess);
         if (openSuccess) {
             this.state = RelpConnectionState.OPEN;
         }
@@ -186,7 +186,7 @@ public class RelpConnection implements RelpSender {
 
      */
     public boolean disconnect() throws IOException, IllegalStateException, TimeoutException {
-        LOGGER.debug("relpConnection.disconnect> entry");
+        LOGGER.trace("relpConnection.disconnect> entry");
         if (state != RelpConnectionState.OPEN) {
             throw new IllegalStateException("Session is not in open state, can not close.");
         }
@@ -199,7 +199,7 @@ public class RelpConnection implements RelpSender {
         if (closeResponse != null && closeResponse.dataLength == 0) {
             closeSuccess = true;
         }
-        LOGGER.debug("relpConnection.disconnect> exit with: " + closeSuccess);
+        LOGGER.trace("relpConnection.disconnect> exit with: " + closeSuccess);
         if(closeSuccess){
             relpClientSocket.close();
             this.state = RelpConnectionState.CLOSED;
@@ -208,14 +208,14 @@ public class RelpConnection implements RelpSender {
     }
 
     public void commit(RelpBatch relpBatch) throws IOException, IllegalStateException, TimeoutException {
-        LOGGER.debug("relpConnection.commit> entry");
+        LOGGER.trace("relpConnection.commit> entry");
         if (this.state != RelpConnectionState.OPEN) {
             throw new IllegalStateException("Session is not in open state, can not commit.");
         }
         this.state = RelpConnectionState.COMMIT;
         this.sendBatch(relpBatch);
         this.state = RelpConnectionState.OPEN;
-        LOGGER.debug("relpConnection.commit> exit");
+        LOGGER.trace("relpConnection.commit> exit");
     }
 
     /**
@@ -226,7 +226,7 @@ public class RelpConnection implements RelpSender {
 
      */
     private void sendBatch(RelpBatch relpBatch)  throws IOException, TimeoutException, IllegalStateException {
-        LOGGER.debug("relpConnection.sendBatch> entry with wq len " + relpBatch.getWorkQueueLength());
+        LOGGER.trace("relpConnection.sendBatch> entry with wq len " + relpBatch.getWorkQueueLength());
         // send a batch of requests..
         RelpFrameTX relpRequest;
 
@@ -242,14 +242,14 @@ public class RelpConnection implements RelpSender {
             sendRelpRequestAsync(relpRequest);
         }
         readAcks(relpBatch);
-        LOGGER.debug("relpConnection.sendBatch> exit");
+        LOGGER.trace("relpConnection.sendBatch> exit");
     }
 
 
 
     private void readAcks(RelpBatch relpBatch)
             throws IOException, TimeoutException, IllegalStateException {
-        LOGGER.debug("relpConnection.readAcks> entry");
+        LOGGER.trace("relpConnection.readAcks> entry");
 
         RelpParser parser = null;
 
@@ -258,11 +258,11 @@ public class RelpConnection implements RelpSender {
         boolean notComplete = this.window.size() > 0;
 
         while (notComplete) {
-            LOGGER.debug("relpConnection.readAcks> need to read");
+            LOGGER.trace("relpConnection.readAcks> need to read");
 
             readBytes = relpClientSocket.read(preAllocatedRXBuffer);
 
-            LOGGER.debug("relpConnection.readAcks> read bytes: " + readBytes);
+            LOGGER.trace("relpConnection.readAcks> read bytes: " + readBytes);
 
             // read from it
             preAllocatedRXBuffer.flip();
@@ -276,7 +276,7 @@ public class RelpConnection implements RelpSender {
                     parser.parse(preAllocatedRXBuffer.get());
 
                     if (parser.isComplete()) {
-                        LOGGER.debug("relpConnection.readAcks> read parser " +
+                        LOGGER.trace("relpConnection.readAcks> read parser " +
                                 "complete: " + parser.isComplete());
                         // one response read successfully
                         int txnId = parser.getTxnId();
@@ -303,20 +303,20 @@ public class RelpConnection implements RelpSender {
             // everything should be read by now
             preAllocatedRXBuffer.compact();
         }
-        LOGGER.debug("relpConnection.readAcks> exit");
+        LOGGER.trace("relpConnection.readAcks> exit");
     }
 
     private void sendRelpRequestAsync(RelpFrameTX relpRequest) throws IOException, TimeoutException {
-        LOGGER.debug("relpConnection.sendRelpRequestAsync> entry");
+        LOGGER.trace("relpConnection.sendRelpRequestAsync> entry");
         ByteBuffer byteBuffer;
         if (relpRequest.length() > this.txBufferSize) {
-            LOGGER.debug("relpConnection.sendRelpRequestAsync> allocate new " +
+            LOGGER.trace("relpConnection.sendRelpRequestAsync> allocate new " +
                     "txBuffer of size: "
                     + relpRequest.length());
             byteBuffer = ByteBuffer.allocateDirect(relpRequest.length());
         }
         else {
-            LOGGER.debug("relpConnection.sendRelpRequestAsync> using " +
+            LOGGER.trace("relpConnection.sendRelpRequestAsync> using " +
                     "preAllocatedTXBuffer for size: "
             + relpRequest.length());
             byteBuffer = this.preAllocatedTXBuffer;
@@ -326,6 +326,6 @@ public class RelpConnection implements RelpSender {
         byteBuffer.flip();
         relpClientSocket.write(byteBuffer);
         byteBuffer.clear();
-        LOGGER.debug("relpConnection.sendRelpRequestAsync> exit");
+        LOGGER.trace("relpConnection.sendRelpRequestAsync> exit");
     }
 }

--- a/src/main/java/com/teragrep/rlp_01/RelpConnection.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpConnection.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLEngine;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 /**
  * Abstract the concept of RELP session: it handles the
@@ -129,13 +130,13 @@ public class RelpConnection implements RelpSender {
         this.relpClientSocket = new RelpClientPlainSocket();
     }
 
-    public RelpConnection(SSLEngine sslEngine) {
+    public RelpConnection(Supplier<SSLEngine> sslEngineSupplier) {
         this.state = RelpConnectionState.CLOSED;
 
         this.setRxBufferSize(512);
         this.setTxBufferSize(262144);
 
-        this.relpClientSocket = new RelpClientTlsSocket(sslEngine);
+        this.relpClientSocket = new RelpClientTlsSocket(sslEngineSupplier);
     }
 
     

--- a/src/main/java/com/teragrep/rlp_01/RelpFrameRX.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpFrameRX.java
@@ -40,7 +40,7 @@ public class RelpFrameRX extends AbstractRelpFrame {
         super(txID, command, dataLength);
         this.data = new byte[src.remaining()];
         src.get(this.data);
-        LOGGER.debug("relpResponse> RelpFrameRX dataLength: " + dataLength);
+        LOGGER.trace("relpResponse> RelpFrameRX dataLength: " + dataLength);
 
     }
 

--- a/src/main/java/com/teragrep/rlp_01/RelpFrameTX.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpFrameTX.java
@@ -58,11 +58,11 @@ public class RelpFrameTX extends AbstractRelpFrame implements Writeable {
      * HEADER DATA TRAILER to the byte buffer.
      */
     public void write(ByteBuffer dst) throws IOException {
-        LOGGER.debug("RelpFrameTX.write> entry");
+        LOGGER.trace("RelpFrameTX.write> entry");
         putHeader(dst);
         putData(dst);
         dst.put((byte)'\n');
-        LOGGER.debug("RelpFrameTX.write> exit");
+        LOGGER.trace("RelpFrameTX.write> exit");
     }
 
     public int length() throws UnsupportedEncodingException {
@@ -91,12 +91,12 @@ public class RelpFrameTX extends AbstractRelpFrame implements Writeable {
      The buffer to write the data into.
      */
     private void putData(ByteBuffer dst) {
-        LOGGER.debug("RelpFrameTX.putData> entry");
+        LOGGER.trace("RelpFrameTX.putData> entry");
         if (this.data != null) {
                 dst.put((byte) ' ');
                 dst.put(this.data);
         }
-        LOGGER.debug("RelpFrameTX.putData> exit");
+        LOGGER.trace("RelpFrameTX.putData> exit");
     }
 
     /**
@@ -107,13 +107,13 @@ public class RelpFrameTX extends AbstractRelpFrame implements Writeable {
      *  Shouldn't happen for US-ASCII..
      */
     private void putHeader(ByteBuffer dst) throws UnsupportedEncodingException {
-        LOGGER.debug("RelpFrameTX.putHeader> entry");
+        LOGGER.trace("RelpFrameTX.putHeader> entry");
         dst.put(Integer.toString(this.transactionNumber).getBytes("US-ASCII"));
         dst.put((byte)' ');
         dst.put(this.command.getBytes("US-ASCII"));
         dst.put((byte)' ');
         dst.put(Integer.toString(this.dataLength).getBytes("US-ASCII"));
-        LOGGER.debug("RelpFrameTX.putHeader> exit");
+        LOGGER.trace("RelpFrameTX.putHeader> exit");
     }
 
     /**


### PR DESCRIPTION
change from SSLEngine argument to Supplier<SSLEngine> for the RelpConnection when tls is desired, reconnect seems to require a fresh SSLEngine each time.