### PR TITLE
change RelpConnection constructor so that reconnect can work

### DIFF
--- a/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
@@ -26,6 +26,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,15 +78,12 @@ public class RelpClientTlsSocket extends RelpClientSocket {
     private SocketChannel socketChannel;
     private Selector selector;
 
-    private final SSLEngine sslEngine;
-
     private TlsChannel tlsChannel = null;
 
-    RelpClientTlsSocket(SSLEngine sslEngine) {
-        this.sslEngine = sslEngine;
+    private final Supplier<SSLEngine> sslEngineSupplier;
 
-        // force client mode
-        this.sslEngine.setUseClientMode(true);
+    RelpClientTlsSocket(Supplier<SSLEngine> sslEngineSupplier) {
+        this.sslEngineSupplier = sslEngineSupplier;
     }
 
     @Override
@@ -104,6 +102,10 @@ public class RelpClientTlsSocket extends RelpClientSocket {
         SelectionKey key = this.socketChannel.register(this.selector, SelectionKey.OP_CONNECT);
         // Async connect
         this.socketChannel.connect(new InetSocketAddress(hostname, port));
+
+        SSLEngine sslEngine = sslEngineSupplier.get();
+        // force client mode
+        sslEngine.setUseClientMode(true);
 
         ClientTlsChannel.Builder builder = ClientTlsChannel.newBuilder(
                 socketChannel,
@@ -166,7 +168,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                     LOGGER.trace("relpConnection.sendRelpRequestAsync> " +
                             "became writable");
                     try {
-                        this.tlsChannel.write(byteBuffer);
+                        int wroteBytes = this.tlsChannel.write(byteBuffer);
                     } catch (NeedsReadException e) {
                         key.interestOps(SelectionKey.OP_READ); // overwrites previous value
                     } catch (NeedsWriteException e) {
@@ -183,6 +185,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
 
     @Override
     void close() throws IOException {
+        tlsChannel.close();
         socketChannel.close();
     }
 
@@ -205,12 +208,17 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                 try {
                     readBytes = tlsChannel.read(byteBuffer);
                 } catch (NeedsReadException e) {
+                    readBytes = 0;
                     key.interestOps(SelectionKey.OP_READ); // overwrites previous value
                 } catch (NeedsWriteException e) {
+                    readBytes = 0;
                     key.interestOps(SelectionKey.OP_WRITE); // overwrites previous value
                 }
             }
             eventIter.remove();
+        }
+        if (readBytes == -1) {
+            throw new IOException("read failed");
         }
         return readBytes;
     }

--- a/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
@@ -186,7 +186,6 @@ public class RelpClientTlsSocket extends RelpClientSocket {
     @Override
     void close() throws IOException {
         tlsChannel.close();
-        socketChannel.close();
     }
 
     @Override

--- a/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpClientTlsSocket.java
@@ -168,7 +168,7 @@ public class RelpClientTlsSocket extends RelpClientSocket {
                     LOGGER.trace("relpConnection.sendRelpRequestAsync> " +
                             "became writable");
                     try {
-                        int wroteBytes = this.tlsChannel.write(byteBuffer);
+                        this.tlsChannel.write(byteBuffer);
                     } catch (NeedsReadException e) {
                         key.interestOps(SelectionKey.OP_READ); // overwrites previous value
                     } catch (NeedsWriteException e) {

--- a/src/main/java/com/teragrep/rlp_01/RelpConnection.java
+++ b/src/main/java/com/teragrep/rlp_01/RelpConnection.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLEngine;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 /**
  * Abstract the concept of RELP session: it handles the
@@ -129,13 +130,13 @@ public class RelpConnection implements RelpSender {
         this.relpClientSocket = new RelpClientPlainSocket();
     }
 
-    public RelpConnection(SSLEngine sslEngine) {
+    public RelpConnection(Supplier<SSLEngine> sslEngineSupplier) {
         this.state = RelpConnectionState.CLOSED;
 
         this.setRxBufferSize(512);
         this.setTxBufferSize(262144);
 
-        this.relpClientSocket = new RelpClientTlsSocket(sslEngine);
+        this.relpClientSocket = new RelpClientTlsSocket(sslEngineSupplier);
     }
 
     


### PR DESCRIPTION
change from SSLEngine argument to Supplier<SSLEngine> for the RelpConnection when tls is desired, reconnect seems to require a fresh SSLEngine each time
